### PR TITLE
Fixed lettings offerer name defect

### DIFF
--- a/properties/templates/properties/emails/new_lettings_deal.txt
+++ b/properties/templates/properties/emails/new_lettings_deal.txt
@@ -7,7 +7,7 @@ There has been a deal put through for:
 
 The offer details are:
 
-Name - {{ offer.offerer_details }}
+Name - {{ offer.offerer_lettings_details }}
 Offer - £{{ humanized_offer }}
 
 The property consultant and hub are: 


### PR DESCRIPTION
Emails for a lettings deal were being sent with a 'None' value for the name. This PR fixes the incorrect link to the lettings field needed.

Old email below:

The offer details are:

Name - None
Offer - £1,000.00
